### PR TITLE
Don't trigger so many change events

### DIFF
--- a/src/bootstrap-rating-input.js
+++ b/src/bootstrap-rating-input.js
@@ -17,8 +17,12 @@
       var self = $(ratingInput);
       self.find('[data-value]').removeClass('glyphicon-star').addClass('glyphicon-star-empty');
       self.find('.rating-clear').hide();
-      var input = self.find('input');
-      input.val(input.data('empty-value')).trigger('change');
+      var input = self.find('input'),
+          val = input.val(),
+          emptyVal = input.data('empty-value');
+      if(emptyVal && emptyVal != val){
+        input.val(emptyVal).trigger('change');
+      }
     }
 
     // Iterate and transform all selected inputs


### PR DESCRIPTION
Currently if the control does not have a value set yet, but does have a minimum and maximum, change events are fired with every mouse hover.

These do not need to be fired so frequently and are only needed if there is a specific empty value and the current value differs from it.
