### PR TITLE
Add (main) module ID to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "bootstrap-rating-input",
   "version": "0.2.5",
   "repository": "https://github.com/javiertoledo/bootstrap-rating-input.git",
+  "main": "src/bootstrap-rating-input.js",
   "devDependencies": {
     "uglify-js": "1.3.5",
     "grunt": "0.4.2",


### PR DESCRIPTION
I'm using bootstrap-rating-input with browserify, which uses npm & thus 'require', so the package.json needs the 'main' element to point npm in the right direction.