### PR TITLE
Store reference to rating object

### DIFF
--- a/src/bootstrap-rating-input.js
+++ b/src/bootstrap-rating-input.js
@@ -146,6 +146,7 @@
             rating.clear();
           });
       }
+      $input.data('rating', rating);
     });
   };
 


### PR DESCRIPTION
Store reference to rating object in input so the rating's internal functions are exposed, e.g. `$('input').data('rating').setValue(4)`. The API could potentially be refactored to be something like `$('input').rating('setValue', 4)` but this much easier to implement.

If there's a way to access the internal API (especially `setValue`) and I'm just overlooking it, please let me know.